### PR TITLE
change property loading. ref env property, and rename property key

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,20 @@ API Keyは`build.gradle`が`project.properties`を参照し,これをstring reso
  1. Android Projectのルートディレクトリに`gradle.properties`ファイルを作成
  2. `project.properties`ファイルに下記のKey-Valueを登録する.
 
-    | key                        | description                  |
-    |----------------------------|------------------------------|
-    | gmap.api.key               | Google Map API Key           |
-    | twitter.consumer.key       | Twitter Consumer Key         |
-    | twitter.consumer.secretkey | Twitter Consumer Securet Key |
+    | key                        | description                 |
+    |----------------------------|-----------------------------|
+    | gmap_api_key               | Google Map API Key          |
+    | twitter_consumer.key       | Twitter Consumer Key        |
+    | twitter_consumer.secretkey | Twitter Consumer Secret Key |
 
 example)
 ```
 # Google API
-gmap.api.key=AIxxxxxxxxxxxxxxxxxxxxxxxxxxx
+gmap_api_key=AIxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # Twitter API
-twitter.consumer.key=xxxxxxxxxxxxxxxxxxxxxxxxxxxx
-twitter.consumer.secretkey=xxxxxxxxxxxxxxxxxxxxxx
+twitter_consumer_key=xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+twitter_consumer_secretkey=xxxxxxxxxxxxxxxxxxxxxx
 ```
 
 ## Copyright

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -83,25 +83,36 @@ def loadConfiguration() {
     ]
 
     // Setup default properties
-    // 後述するproject.propertiesが定義されない場合はEnvironment variablesが参照される. 
-    // Environment variablesもない場合は"UNDEFINE"がデフォルト値として設定される.
+    //   後述するproject.propertiesが定義されない場合はEnvironment variablesが参照される. 
+    //   Environment variablesもない場合は"UNDEFINE"がデフォルト値として設定される.
     PROPERTY_KEYS.each { k ->
         String envVar = System.getenv(k)
         prop.setProperty k, envVar == null ? "UNDEFINE" : envVar
     }
 
     // ** ATTENTION! **
-    // レポジトリをcloneしたあとはプロジェクトルートディレクトリ直下に project.properties ファイルを作成してください. 
-    // project.propertiesにはTwitterとGoogle MapsのAPI Keyを下記要領に従って定義してください. 
+    //   レポジトリをcloneしたあとはプロジェクトルートディレクトリ直下に project.properties ファイルを作成してください. 
+    //   project.propertiesにはTwitterとGoogle MapsのAPI Keyを下記要領に従って定義してください. 
     //   https://github.com/TweetMap/TweetMapForAndroid#setup-configurations
     File f = project.rootProject.file('project.properties')
     if (f.exists()) {
         prop.load(f.newDataInputStream())
     } else {
-        
+        // N.O.P. 前述のデフォルトプロパティが参照される.
     }
     
+    // NOTE:
+    //   Unsafe fork PR builds
+    //   In the event that you want these four categories of configuration to be made available, 
+    //   or you need to run fork PR builds for private repositories, 
+    //   you need to affirmatively enable it because of these security issues.
+    //   
+    //   There is a per-project flag (in Project settings > Experimental Settings > Project fork pull requests) 
+    //   which will cause us to run builds of all fork pull requests without suppressing any of the sensitive information listed above.
+    //   https://circleci.com/docs/fork-pr-builds#unsafe-fork-pr-builds
     println "Load configuration..."
+    println "If this build is due to pull request, " +
+            "Environment variable is not set correctly by the security policy."
     prop.each { p ->
         println "  " + p
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,9 +28,9 @@ android {
         versionName "0.0.1"
 
         ConfigObject config = loadConfiguration()
-        resValue "string", "google_maps_api_key", config.gmap.api.key
-        resValue "string", "twitter_consumer_key", config.twitter.consumer.key
-        resValue "string", "twitter_consumer_secret_key", config.twitter.consumer.secretkey
+        resValue "string", "google_maps_api_key", config.gmap_api_key
+        resValue "string", "twitter_consumer_key", config.twitter_consumer_key
+        resValue "string", "twitter_consumer_secret_key", config.twitter_consumer_secretkey
     }
 
     buildTypes {
@@ -76,6 +76,20 @@ dependencies {
 def loadConfiguration() {
     def prop = new Properties()
 
+    final def PROPERTY_KEYS = [
+            "gmap_api_key",
+            "twitter_consumer_key",
+            "twitter_consumer_secretkey",
+    ]
+
+    // Setup default properties
+    // 後述するproject.propertiesが定義されない場合はEnvironment variablesが参照される. 
+    // Environment variablesもない場合は"UNDEFINE"がデフォルト値として設定される.
+    PROPERTY_KEYS.each { k ->
+        String envVar = System.getenv(k)
+        prop.setProperty k, envVar == null ? "UNDEFINE" : envVar
+    }
+
     // ** ATTENTION! **
     // レポジトリをcloneしたあとはプロジェクトルートディレクトリ直下に project.properties ファイルを作成してください. 
     // project.propertiesにはTwitterとGoogle MapsのAPI Keyを下記要領に従って定義してください. 
@@ -84,18 +98,13 @@ def loadConfiguration() {
     if (f.exists()) {
         prop.load(f.newDataInputStream())
     } else {
-        // Fallback api keys
-        prop.setProperty "gmap.api.key", "UNDEFINED"
-        prop.setProperty "twitter.consumer.key", "UNDEFINED"
-        prop.setProperty "twitter.consumer.secretkey", "UNDEFINED"
+        
     }
-
-
-    println "Load configuration... ===>"
+    
+    println "Load configuration..."
     prop.each { p ->
-        println p
+        println "  " + p
     }
-    println "<==="
 
     return new ConfigSlurper().parse(prop)
 }


### PR DESCRIPTION
Circle CIのenvironment variableのkey値にドット"."が許容されないため、プロパティのkey値をアンダースコア"_"に変更. 
また, CircleCI側で設定したenvironment variableを参照するようにbuild.gradleを変更. 
