### PR TITLE
disable lint option abortOnError false

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,6 +44,10 @@ android {
         }
     }
 
+    lintOptions {
+        abortOnError false
+    }
+
     packagingOptions {
         exclude 'META-INF/NOTICE.txt'
         exclude 'META-INF/LICENSE.txt'


### PR DESCRIPTION
ビルド時にlintでエラーが発生してもビルド継続させる対応.
